### PR TITLE
Added brvs status subscription to unlock accounts properly

### DIFF
--- a/brvs-core/src/main/java/iroha/validation/service/impl/ValidationServiceImpl.java
+++ b/brvs-core/src/main/java/iroha/validation/service/impl/ValidationServiceImpl.java
@@ -54,7 +54,6 @@ public class ValidationServiceImpl implements ValidationService {
               if (Verdict.VALIDATED != validationResult.getStatus()) {
                 final String reason = validationResult.getReason();
                 transactionSigner.rejectAndSend(transactionBatch, reason);
-                logger.info("Transactions has been rejected by the service. Reason: " + reason);
                 verdict = false;
                 break;
               }
@@ -62,7 +61,6 @@ public class ValidationServiceImpl implements ValidationService {
           }
           if (verdict) {
             transactionSigner.signAndSend(transactionBatch);
-            logger.info("Transactions has been successfully validated and signed");
           }
         }
     );

--- a/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/AccountManager.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/AccountManager.java
@@ -11,6 +11,7 @@ import iroha.protocol.TransactionOuterClass;
 import iroha.validation.transactions.provider.RegistrationProvider;
 import iroha.validation.transactions.provider.UserQuorumProvider;
 import iroha.validation.transactions.provider.impl.util.BrvsData;
+import iroha.validation.utils.ValidationUtils;
 import java.security.Key;
 import java.security.KeyPair;
 import java.util.Arrays;
@@ -45,16 +46,6 @@ public class AccountManager implements UserQuorumProvider, RegistrationProvider 
   // BRVS keys count = User keys count
   private static final int PROPORTION = 2;
   private static final JsonParser parser = new JsonParser();
-  private static final SubscriptionStrategy subscriptionStrategy = new WaitForTerminalStatus(
-      Arrays.asList(
-          TxStatus.STATELESS_VALIDATION_FAILED,
-          TxStatus.STATEFUL_VALIDATION_FAILED,
-          TxStatus.COMMITTED,
-          TxStatus.MST_EXPIRED,
-          TxStatus.REJECTED,
-          TxStatus.UNRECOGNIZED
-      )
-  );
   private static final int INITIAL_KEYS_AMOUNT = 1;
 
   private final Set<String> registeredAccounts = new HashSet<>();
@@ -449,7 +440,7 @@ public class AccountManager implements UserQuorumProvider, RegistrationProvider 
       TransactionOuterClass.Transaction transaction) {
     return irohaAPI.transaction(
         transaction,
-        subscriptionStrategy
+        ValidationUtils.subscriptionStrategy
     ).blockingLast().getTxStatus();
   }
 }

--- a/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/BasicTransactionProvider.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/BasicTransactionProvider.java
@@ -119,7 +119,7 @@ public class BasicTransactionProvider implements TransactionProvider {
   }
 
   private void processRejectedTransactions() {
-    transactionVerdictStorage.getRejectedTransactionsHashesStreaming()
+    transactionVerdictStorage.getRejectedOrFailedTransactionsHashesStreaming()
         .subscribe(this::tryToRemoveLock);
   }
 

--- a/brvs-core/src/main/java/iroha/validation/transactions/signatory/impl/TransactionSignerImpl.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/signatory/impl/TransactionSignerImpl.java
@@ -152,7 +152,7 @@ public class TransactionSignerImpl implements TransactionSigner {
       }
       transactions.add(parsedTransaction.build());
     }
-    sendTransactions(transactions, true);
+    sendTransactions(transactions, false);
   }
 
   private void sendBrvsTransactionBatch(TransactionBatch transactionBatch, KeyPair keyPair) {

--- a/brvs-core/src/main/java/iroha/validation/transactions/signatory/impl/TransactionSignerImpl.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/signatory/impl/TransactionSignerImpl.java
@@ -1,6 +1,10 @@
 package iroha.validation.transactions.signatory.impl;
 
+import io.reactivex.Scheduler;
+import io.reactivex.schedulers.Schedulers;
 import iroha.protocol.Commands.Command;
+import iroha.protocol.Endpoint.ToriiResponse;
+import iroha.protocol.Endpoint.TxStatus;
 import iroha.protocol.TransactionOuterClass.Transaction;
 import iroha.validation.transactions.TransactionBatch;
 import iroha.validation.transactions.signatory.TransactionSigner;
@@ -10,16 +14,20 @@ import java.security.KeyPair;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import jp.co.soramitsu.iroha.java.IrohaAPI;
 import jp.co.soramitsu.iroha.java.Utils;
 import jp.co.soramitsu.iroha.java.detail.BuildableAndSignable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 public class TransactionSignerImpl implements TransactionSigner {
 
+  private static final Logger logger = LoggerFactory.getLogger(TransactionSignerImpl.class);
   private static final KeyPair fakeKeyPair = Utils.parseHexKeypair(
       "0000000000000000000000000000000000000000000000000000000000000000",
       "0000000000000000000000000000000000000000000000000000000000000000"
@@ -30,6 +38,7 @@ public class TransactionSignerImpl implements TransactionSigner {
   private final KeyPair brvsAccountKeyPair;
   private final List<KeyPair> keyPairs;
   private final TransactionVerdictStorage transactionVerdictStorage;
+  private final Scheduler scheduler = Schedulers.from(Executors.newCachedThreadPool());
 
   public TransactionSignerImpl(IrohaAPI irohaAPI,
       List<KeyPair> keyPairs,
@@ -61,6 +70,7 @@ public class TransactionSignerImpl implements TransactionSigner {
     for (Transaction transaction : transactionBatch) {
       transactionVerdictStorage.markTransactionValidated(ValidationUtils.hexHash(transaction));
     }
+    logger.info("Transactions has been successfully validated and signed");
     if (isCreatedByBrvs(transactionBatch)) {
       sendBrvsTransactionBatch(transactionBatch, brvsAccountKeyPair);
     } else {
@@ -93,10 +103,37 @@ public class TransactionSignerImpl implements TransactionSigner {
       }
       transactions.add(parsedTransaction.build());
     }
+    sendTransactions(transactions, true);
+  }
+
+  private void sendTransactions(List<Transaction> transactions, boolean check) {
     if (transactions.size() > 1) {
       irohaAPI.transactionListSync(transactions);
+      for (Transaction transaction : transactions) {
+        if (check) {
+          checkIrohaStatus(transaction);
+        }
+      }
     } else {
-      irohaAPI.transactionSync(transactions.get(0));
+      final Transaction transaction = transactions.get(0);
+      irohaAPI.transactionSync(transaction);
+      if (check) {
+        checkIrohaStatus(transaction);
+      }
+    }
+  }
+
+  private void checkIrohaStatus(Transaction transaction) {
+    final ToriiResponse statusResponse = ValidationUtils.subscriptionStrategy
+        .subscribe(irohaAPI, Utils.hash(transaction))
+        .subscribeOn(scheduler).blockingLast();
+    if (!statusResponse.getTxStatus().equals(TxStatus.COMMITTED)) {
+      logger.warn("Transaction " + ValidationUtils.hexHash(transaction) + " failed in Iroha: "
+          + statusResponse.getTxStatus());
+      transactionVerdictStorage.markTransactionFailed(
+          ValidationUtils.hexHash(transaction),
+          statusResponse.getTxStatus() + " : " + statusResponse.getErrOrCmdName()
+      );
     }
   }
 
@@ -115,11 +152,7 @@ public class TransactionSignerImpl implements TransactionSigner {
       }
       transactions.add(parsedTransaction.build());
     }
-    if (transactions.size() > 1) {
-      irohaAPI.transactionListSync(transactions);
-    } else {
-      irohaAPI.transactionSync(transactions.get(0));
-    }
+    sendTransactions(transactions, true);
   }
 
   private void sendBrvsTransactionBatch(TransactionBatch transactionBatch, KeyPair keyPair) {
@@ -142,24 +175,14 @@ public class TransactionSignerImpl implements TransactionSigner {
       }
     }
 
-    final List<Transaction> transactionList = transactionBatch.getTransactionList();
-    if (transactionList.size() > 1) {
-      irohaAPI.transactionListSync(
-          transactionList
-              .stream()
-              .map(jp.co.soramitsu.iroha.java.Transaction::parseFrom)
-              .map(transaction -> transaction.sign(brvsAccountKeyPair))
-              .map(BuildableAndSignable::build)
-              .collect(Collectors.toList())
-      );
-    } else {
-      irohaAPI.transactionSync(
-          jp.co.soramitsu.iroha.java.Transaction
-              .parseFrom(transactionList.get(0))
-              .sign(brvsAccountKeyPair)
-              .build()
-      );
-    }
+    final List<Transaction> transactions = transactionBatch.getTransactionList()
+        .stream()
+        .map(jp.co.soramitsu.iroha.java.Transaction::parseFrom)
+        .map(transaction -> transaction.sign(keyPair))
+        .map(BuildableAndSignable::build)
+        .collect(Collectors.toList());
+
+    sendTransactions(transactions, true);
   }
 
   /**
@@ -173,6 +196,7 @@ public class TransactionSignerImpl implements TransactionSigner {
           reason
       );
     }
+    logger.info("Transactions has been rejected by the service. Reason: " + reason);
     if (isCreatedByBrvs(transactionBatch)) {
       sendBrvsTransactionBatch(transactionBatch, fakeKeyPair);
     } else {

--- a/brvs-core/src/main/java/iroha/validation/transactions/storage/TransactionVerdictStorage.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/storage/TransactionVerdictStorage.java
@@ -36,6 +36,14 @@ public interface TransactionVerdictStorage extends Closeable {
   void markTransactionRejected(String txHash, String reason);
 
   /**
+   * Method for saving transaction verdict as failed by a reason to a storage
+   *
+   * @param txHash transaction hash
+   * @param reason reason
+   */
+  void markTransactionFailed(String txHash, String reason);
+
+  /**
    * Method for retrieving transaction validation verdict
    *
    * @param txHash transaction hash
@@ -47,5 +55,5 @@ public interface TransactionVerdictStorage extends Closeable {
    *
    * @return {@link Observable} of transactions hashes
    */
-  Observable<String> getRejectedTransactionsHashesStreaming();
+  Observable<String> getRejectedOrFailedTransactionsHashesStreaming();
 }

--- a/brvs-core/src/main/java/iroha/validation/transactions/storage/impl/dummy/DummyMemoryTransactionVerdictStorage.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/storage/impl/dummy/DummyMemoryTransactionVerdictStorage.java
@@ -45,6 +45,12 @@ public class DummyMemoryTransactionVerdictStorage implements TransactionVerdictS
     subject.onNext(txHash);
   }
 
+  @Override
+  public void markTransactionFailed(String txHash, String reason) {
+    validationResultMap.put(txHash.toUpperCase(), ValidationResult.FAILED(reason));
+    subject.onNext(txHash);
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -57,7 +63,7 @@ public class DummyMemoryTransactionVerdictStorage implements TransactionVerdictS
    * {@inheritDoc}
    */
   @Override
-  public Observable<String> getRejectedTransactionsHashesStreaming() {
+  public Observable<String> getRejectedOrFailedTransactionsHashesStreaming() {
     return subject;
   }
 

--- a/brvs-core/src/main/java/iroha/validation/transactions/storage/impl/mongo/MongoTransactionVerdictStorage.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/storage/impl/mongo/MongoTransactionVerdictStorage.java
@@ -77,6 +77,13 @@ public class MongoTransactionVerdictStorage implements TransactionVerdictStorage
     subject.onNext(upperCaseHash);
   }
 
+  @Override
+  public void markTransactionFailed(String txHash, String reason) {
+    final String upperCaseHash = txHash.toUpperCase();
+    store(upperCaseHash, ValidationResult.FAILED(reason));
+    subject.onNext(upperCaseHash);
+  }
+
   /**
    * {@inheritDoc}
    */
@@ -90,7 +97,7 @@ public class MongoTransactionVerdictStorage implements TransactionVerdictStorage
    * {@inheritDoc}
    */
   @Override
-  public Observable<String> getRejectedTransactionsHashesStreaming() {
+  public Observable<String> getRejectedOrFailedTransactionsHashesStreaming() {
     return subject;
   }
 

--- a/brvs-core/src/main/java/iroha/validation/utils/ValidationUtils.java
+++ b/brvs-core/src/main/java/iroha/validation/utils/ValidationUtils.java
@@ -2,6 +2,7 @@ package iroha.validation.utils;
 
 import com.google.common.collect.ImmutableList;
 import iroha.protocol.BlockOuterClass.Block;
+import iroha.protocol.Endpoint.TxStatus;
 import iroha.protocol.TransactionOuterClass.Transaction;
 import iroha.validation.transactions.TransactionBatch;
 import java.io.IOException;
@@ -10,15 +11,29 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.xml.bind.DatatypeConverter;
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3;
 import jp.co.soramitsu.iroha.java.Utils;
+import jp.co.soramitsu.iroha.java.subscription.SubscriptionStrategy;
+import jp.co.soramitsu.iroha.java.subscription.WaitForTerminalStatus;
 
 public interface ValidationUtils {
 
   Ed25519Sha3 crypto = new Ed25519Sha3();
+
+  SubscriptionStrategy subscriptionStrategy = new WaitForTerminalStatus(
+      Arrays.asList(
+          TxStatus.STATELESS_VALIDATION_FAILED,
+          TxStatus.STATEFUL_VALIDATION_FAILED,
+          TxStatus.COMMITTED,
+          TxStatus.MST_EXPIRED,
+          TxStatus.REJECTED,
+          TxStatus.UNRECOGNIZED
+      )
+  );
 
   static String getTxAccountId(final Transaction transaction) {
     return transaction.getPayload().getReducedPayload().getCreatorAccountId();

--- a/brvs-rules/src/main/java/iroha/validation/verdict/ValidationResult.java
+++ b/brvs-rules/src/main/java/iroha/validation/verdict/ValidationResult.java
@@ -7,6 +7,9 @@ public class ValidationResult {
   public static ValidationResult REJECTED(String reason) {
     return new ValidationResult(Verdict.REJECTED, reason);
   }
+  public static ValidationResult FAILED(String reason) {
+    return new ValidationResult(Verdict.FAILED, reason);
+  }
 
   private Verdict status;
 

--- a/brvs-rules/src/main/java/iroha/validation/verdict/Verdict.java
+++ b/brvs-rules/src/main/java/iroha/validation/verdict/Verdict.java
@@ -1,5 +1,5 @@
 package iroha.validation.verdict;
 
 public enum Verdict {
-  UNKNOWN, VALIDATED, REJECTED
+  UNKNOWN, VALIDATED, REJECTED, FAILED
 }


### PR DESCRIPTION
Now brvs checks validated transaction status to unlock account if something goes wrong in Iroha. In previous version brvs would wait for the COMMITTED only of a validated transaction in Iroha. Moreover now brvs unlocks accounts in both REJECT by brvs and error in Iroha outcomes.