### PR TITLE
Signatories are back instead of quorums

### DIFF
--- a/brvs-rules/src/main/java/iroha/validation/rules/impl/core/NoQuorumModificationsRule.java
+++ b/brvs-rules/src/main/java/iroha/validation/rules/impl/core/NoQuorumModificationsRule.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright D3 Ledger, Inc. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package iroha.validation.rules.impl.core;
+
+import iroha.protocol.Commands.Command;
+import iroha.protocol.TransactionOuterClass.Transaction;
+import iroha.validation.rules.Rule;
+import iroha.validation.verdict.ValidationResult;
+
+public class NoQuorumModificationsRule implements Rule {
+
+  @Override
+  public ValidationResult isSatisfiedBy(Transaction transaction) {
+    if (transaction.getPayload().getReducedPayload().getCommandsList().stream()
+        .anyMatch(Command::hasSetAccountQuorum)) {
+      return ValidationResult.REJECTED("User is not allowed to change their quorum");
+    }
+    return ValidationResult.VALIDATED;
+  }
+}

--- a/config/context/spring-context.xml
+++ b/config/context/spring-context.xml
@@ -169,9 +169,6 @@
     <constructor-arg name="queryAPI" ref="queryAPI"/>
     <constructor-arg name="amount" value="${MIN_SIGNATORIES_RULE_AMOUNT}"/>
   </bean>
-  <bean id="quorumDivisor" class="iroha.validation.rules.impl.core.QuorumDivisorRule">
-    <constructor-arg name="divisor" value="${QUORUM_DIVISOR_RULE_VALUE}"/>
-  </bean>
   <bean id="billingRule" class="iroha.validation.rules.impl.billing.BillingRule">
     <constructor-arg name="getBillingURL" value="${BILLING_URL}"/>
     <constructor-arg name="getAssetPrecisionURL" value="${BILLING_ASSET_PRECISION_URL}"/>
@@ -183,14 +180,15 @@
     <constructor-arg name="depositAccounts" value="${BILLING_DEPOSITACCOUNTS}"/>
     <constructor-arg name="withdrawalAccounts" value="${BILLING_WITHDRAWALACCOUNTS}"/>
   </bean>
+  <bean id="quorumBanRule" class="iroha.validation.rules.impl.core.NoQuorumModificationsRule"/>
   <util:map id="rules" map-class="java.util.HashMap">
     <entry key="updateWhitelistRule" value-ref="updateWhitelistRule"/>
     <entry key="checkEthWhitelistRule" value-ref="checkEthWhitelistRule"/>
     <entry key="checkBtcWhitelistRule" value-ref="checkBtcWhitelistRule"/>
     <entry key="restrictedKeysRule" value-ref="restrictedKeysRule"/>
     <entry key="minKeysRule" value-ref="minKeysRule"/>
-    <entry key="quorumDivisor" value-ref="quorumDivisor"/>
     <entry key="billingRule" value-ref="billingRule"/>
+    <entry key="quorumBanRule" value-ref="quorumBanRule"/>
     <!-- More can be added -->
   </util:map>
 


### PR DESCRIPTION
Users are not allowed to change their quorum. BRVS reacts on signatories modification instead.

Merge with frontend update.